### PR TITLE
Fix: prevent crash when stdoutRing or stderrRing is undefined by @decompi

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -467,7 +467,11 @@ module.exports = function(proto) {
             self.processTimer = setTimeout(function() {
               var msg = 'process ran into a timeout (' + self.options.timeout + 's)';
 
-              emitEnd(new Error(msg), stdoutRing.get(), stderrRing.get());
+              if (!stdoutRing || !stderrRing) { 
+                self.logger?.warn?.('stdoutRing or stderrRing is undefined during timeout.');
+              } 
+              
+              emitEnd( new Error(msg), stdoutRing?.get?.() ?? null, stderrRing?.get?.() ?? null );
               ffmpegProc.kill();
             }, self.options.timeout * 1000);
           }
@@ -495,7 +499,10 @@ module.exports = function(proto) {
               self.logger.debug('Output stream error, killing ffmpeg process');
               var reportingErr = new Error('Output stream error: ' + err.message);
               reportingErr.outputStreamError = err;
-              emitEnd(reportingErr, stdoutRing.get(), stderrRing.get());
+              if (!stdoutRing || !stderrRing) { 
+                self.logger?.warn?.('stdoutRing or stderrRing is undefined during output stream error.'); 
+              } 
+              emitEnd( reportingErr, stdoutRing?.get?.() ?? null, stderrRing?.get?.() ?? null );
               ffmpegProc.kill('SIGKILL');
             });
           }
@@ -540,7 +547,11 @@ module.exports = function(proto) {
               err.message += ': ' + utils.extractError(stderrRing.get());
             }
 
-            emitEnd(err, stdoutRing.get(), stderrRing.get());
+            if(!stdoutRing || !stderrRing) {
+              self.logger?.warn?.('stdoutRing or stderrRing is undefined – FFmpeg may have exited early.')
+            }
+            
+            emitEnd( err, stdoutRing?.get?.() ?? null, stderrRing?.get?.() ?? null );
           } else {
             // Find out which outputs need flv metadata
             var flvmeta = self._outputs.filter(function(output) {


### PR DESCRIPTION
Fork from: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1321 by @decompi

This pull request fixes a bug that causes fluent-ffmpeg to crash when stdoutRing or stderrRing are undefined which happens when FFmpeg exits early or fails to spawn properly.

Problem:
In some rare cases (see https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/1316 ), the following error occurs:

TypeError: Cannot read properties of undefined (reading 'get')
    at emitEnd (.../lib/processor.js:543:37)
This indicates stdoutRing or stderrRing may have not been initialized in time

My Patch:

Adds a null-safe check using stdoutRing?.get?.() and fallback to null if undefined.
Logs a warning when either ring is unexpectedly missing
Changed Lines:

Line 470 (timeout handler)
Line 502(output stream err handler)
Line 550 (final endCB cleanup)