### PR TITLE
chore(npm): add coverage and .vscode directories to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 .git*
 test/
 examples/
+coverage/
+.vscode/


### PR DESCRIPTION
Forked from: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1313  by @thejimbow

This PR adds the coverage directory to the .npmignore file. Currently, the published package includes the coverage directory, resulting in an unnecessarily large package size (~12MB). By ignoring this directory, we ensure the package remains lightweight and focused, improving installation efficiency for users.

Let me know if there's anything else you'd like me to include!
<img width="1776" height="370" alt="image" src="https://github.com/user-attachments/assets/3689cb5e-b13b-492d-a04f-9b4d8db1219c" />
