### PR TITLE
Add AbortSignal to ffmpeg/ffprobe spawning

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -136,6 +136,7 @@ module.exports = function(proto) {
         return handleCallback(new Error('Invalid input index'));
       }
     }
+    var signal = this.options.signal;
 
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
@@ -152,7 +153,7 @@ module.exports = function(proto) {
 
       // Spawn ffprobe
       var src = input.isStream ? 'pipe:0' : input.source;
-      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src), {windowsHide: true});
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src), {windowsHide: true, signal});
 
       if (input.isStream) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -27,6 +27,7 @@ var ARGLISTS = ['_global', '_audio', '_audioFilters', '_video', '_videoFilters',
  * @param {String} [options.stdoutLines=100] maximum lines of ffmpeg output to keep in memory, use 0 for unlimited
  * @param {Number} [options.timeout=<no timeout>] ffmpeg processing timeout in seconds
  * @param {String|ReadableStream} [options.source=<no input>] alias for the `input` parameter
+ * @param {AbortSignal} [options.signal=<no input>] an AbortSignal to cancel the command
  */
 function FfmpegCommand(input, options) {
   // Make 'new' optional

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -438,7 +438,8 @@ module.exports = function(proto) {
           captureStdout: !outputStream,
           niceness: self.options.niceness,
           cwd: self.options.cwd,
-          windowsHide: true
+          windowsHide: true,
+          signal: self.options.signal
         }, 
 
         function processCB(ffmpegProc, stdoutRing, stderrRing) {
@@ -556,7 +557,7 @@ module.exports = function(proto) {
                 async.each(
                   flvmeta,
                   function(output, cb) {
-                    spawn(flvtool, ['-U', output.target], {windowsHide: true})
+                    spawn(flvtool, ['-U', output.target], {windowsHide: true, signal: self.options.signal})
                       .on('error', function(err) {
                         cb(new Error('Error running ' + flvtool + ' on ' + output.target + ': ' + err.message));
                       })
@@ -619,7 +620,7 @@ module.exports = function(proto) {
       if (this.ffmpegProc) {
         var logger = this.logger;
         var pid = this.ffmpegProc.pid;
-        var renice = spawn('renice', [niceness, '-p', pid], {windowsHide: true});
+        var renice = spawn('renice', [niceness, '-p', pid], {windowsHide: true, signal: this.options.signal});
 
         renice.on('error', function(err) {
           logger.warn('could not renice process ' + pid + ': ' + err.message);


### PR DESCRIPTION
Forked from https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1288 by @danielz-mnx 

Adds a AbortSignal to the child spawning so that if the outer execution context requires it the operation can be instantly aborted. This also helps with timeouts (see pull request https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/976#issue-542505084), which should not be fluent-ffmpeg's responsibility.