### PR TITLE
fix: Add output format for the pipe() example #1277 by @lin826

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,7 @@ var command = ffmpeg('/path/to/file.avi')
   .videoCodec('libx264')
   .audioCodec('libmp3lame')
   .size('320x240')
+  .format('flv')
   .on('error', function(err) {
     console.log('An error occurred: ' + err.message);
   })


### PR DESCRIPTION
Forked from https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1277 by @lin826

fix https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/539