### PR TITLE
[activationBytes] Add support for -activation_bytes option #1252 by @moeadham

### DIFF
--- a/lib/options/inputs.js
+++ b/lib/options/inputs.js
@@ -192,4 +192,38 @@ module.exports = function(proto) {
     this._currentInput.options('-activation_bytes', bytes);
     return this;
   };
+
+  /**
+   * Specify audible key for the last specified input
+   *
+   * @method FfmpegCommand#audibleKey
+   * @category Input
+   * @param {String} key audible key
+   * @return FfmpegCommand
+   */
+  proto.audibleKey = function(key) {
+    if (!this._currentInput) {
+      throw new Error('No input specified');
+    }
+
+    this._currentInput.options('-audible_key', key);
+    return this;
+  };
+
+  /**
+   * Specify audible IV for the last specified input
+   *
+   * @method FfmpegCommand#audibleIv
+   * @category Input
+   * @param {String} iv audible IV
+   * @return FfmpegCommand
+   */
+  proto.audibleIv = function(iv) {
+    if (!this._currentInput) {
+      throw new Error('No input specified');
+    }
+
+    this._currentInput.options('-audible_iv', iv);
+    return this;
+  };
 };

--- a/lib/options/inputs.js
+++ b/lib/options/inputs.js
@@ -175,4 +175,21 @@ module.exports = function(proto) {
 
     return this;
   };
+
+  /**
+   * Specify activation bytes for the last specified input
+   *
+   * @method FfmpegCommand#activationBytes
+   * @category Input
+   * @param {String} bytes activation bytes
+   * @return FfmpegCommand
+   */
+  proto.activationBytes = function(bytes) {
+    if (!this._currentInput) {
+      throw new Error('No input specified');
+    }
+
+    this._currentInput.options('-activation_bytes', bytes);
+    return this;
+  };
 };

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -1119,4 +1119,21 @@ describe('Command', function() {
       });
     });
   });
+  describe('activationBytes', function() {
+    it('should apply activation bytes to input', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .activationBytes('12345678')
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+  
+          // Check if the '-activation_bytes' option is correctly applied
+          const activationBytesIndex = args.indexOf('-activation_bytes');
+          assert.ok(activationBytesIndex !== -1, 'Activation bytes option not found');
+          assert.strictEqual(args[activationBytesIndex + 1], '12345678', 'Activation bytes value does not match');
+  
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
Forked from https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1252 by @moeadham

Assists with conversion of AAX files if the activation bytes are available.